### PR TITLE
feat: Use customized font-family for texts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.10.5",
+    "@next/font": "^13.0.5",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.8",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,20 @@ import facepaint from 'facepaint'
 import { DefaultSeo } from 'next-seo'
 import { GTagManager } from '@/components/GTagManager'
 import { useRouter } from 'next/router'
+import { Zen_Kaku_Gothic_New } from '@next/font/google'
+
+const fontZenKakuGothicNew = Zen_Kaku_Gothic_New({
+  weight: ['500'],
+  subsets: ['japanese'],
+  display: 'swap',
+  fallback: [
+    '-apple-system',
+    'Yu Gothic Medium',
+    'YuGothic',
+    'Meiryo',
+    'sans-serif',
+  ],
+})
 
 export const mq = facepaint([
   '@media(min-width: 720px)',
@@ -24,7 +38,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <Global
         styles={mq({
           'html, body': {
-            fontFamily: 'sans-serif',
+            fontFamily: `'Helvetica Neue', 'Arial', ${fontZenKakuGothicNew.style.fontFamily}`,
             fontSize: ['14px', '1.2vw'],
           },
           p: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,11 @@
   dependencies:
     glob "7.1.7"
 
+"@next/font@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.0.5.tgz#db0ef389d926d3a8b649db8aa76e67f9502a478f"
+  integrity sha512-NrP4B8pxwerrkkuG/m7MQv0ks89Kk4Lc0kzbiRaYX+Xb0coDaw+I9T+g42aOHf8j8ta1vtKqb5XE1+troZ4CoQ==
+
 "@next/swc-android-arm-eabi@13.0.2":
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.2.tgz#66669b8aab5062f554b8e9905d855679aabf0342"


### PR DESCRIPTION
Resolves #15 

Note: using Helvetica Neue, Arial and [Zen Kaku Gothic New](https://fonts.google.com/specimen/Zen+Kaku+Gothic+New?subset=japanese) as primary family, and `-apple-system` and Yu Gothic for fallback. Actually the designer requested [Futo Go B101](https://en.morisawa.co.jp/fonts/specimen/2507) but Typekit allows only 1000 PVs for free account, so these config are used as alternative.