### PR TITLE
fix: Set `sizes` for images

### DIFF
--- a/src/components/PageIndexSectionArticles.tsx
+++ b/src/components/PageIndexSectionArticles.tsx
@@ -59,6 +59,8 @@ const Article: React.FC<ArticleProp> = ({
         alt=""
         width="250"
         height="250"
+        sizes="(max-width: 720px) 100vw, 250px"
+        placeholder="blur"
       />
       <div css={mq({ padding: ['0.7rem', '1rem 2rem'] })}>
         <h3 css={{ fontSize: '1em' }}>{title}</h3>

--- a/src/components/PageIndexSectionHeroIntro.tsx
+++ b/src/components/PageIndexSectionHeroIntro.tsx
@@ -31,6 +31,7 @@ export const PageIndexSectionIntro: React.FC = () => (
         alt=""
         width="500"
         height="300"
+        sizes="(max-width: 720px) 100vw, 866px"
         placeholder="blur"
       ></Image>
       <Image
@@ -38,6 +39,7 @@ export const PageIndexSectionIntro: React.FC = () => (
         alt=""
         width="500"
         height="300"
+        sizes="(max-width: 720px) 100vw, 866px"
         placeholder="blur"
       ></Image>
       <Image
@@ -45,6 +47,7 @@ export const PageIndexSectionIntro: React.FC = () => (
         alt=""
         width="500"
         height="300"
+        sizes="(max-width: 720px) 100vw, 866px"
         placeholder="blur"
       ></Image>
       <Image
@@ -52,6 +55,7 @@ export const PageIndexSectionIntro: React.FC = () => (
         alt=""
         width="500"
         height="300"
+        sizes="(max-width: 720px) 100vw, 866px"
         placeholder="blur"
       ></Image>
       <Image
@@ -59,6 +63,7 @@ export const PageIndexSectionIntro: React.FC = () => (
         alt=""
         width="500"
         height="300"
+        sizes="(max-width: 720px) 100vw, 866px"
         placeholder="blur"
       ></Image>
       <Image
@@ -66,6 +71,7 @@ export const PageIndexSectionIntro: React.FC = () => (
         alt=""
         width="500"
         height="300"
+        sizes="(max-width: 720px) 100vw, 866px"
         placeholder="blur"
       ></Image>
     </TextWrap>

--- a/src/components/PageIndexSectionWorks.tsx
+++ b/src/components/PageIndexSectionWorks.tsx
@@ -92,6 +92,7 @@ export const PageIndexSectionWorks: React.FC = () => {
           width="500"
           height="300"
           alt=""
+          sizes="(max-width: 720px) 100vw, 866px"
           placeholder="blur"
         />
         <Image
@@ -99,6 +100,7 @@ export const PageIndexSectionWorks: React.FC = () => {
           width="500"
           height="300"
           alt=""
+          sizes="(max-width: 720px) 100vw, 866px"
           placeholder="blur"
         />
         <Image
@@ -106,6 +108,7 @@ export const PageIndexSectionWorks: React.FC = () => {
           width="500"
           height="300"
           alt=""
+          sizes="(max-width: 720px) 100vw, 866px"
           placeholder="blur"
         />
       </TextWrap>


### PR DESCRIPTION
From Lighthouse tests